### PR TITLE
Fix warnings in ili9341.cpp

### DIFF
--- a/ili9341.cpp
+++ b/ili9341.cpp
@@ -21,6 +21,113 @@
 #include "Font5x7.h"
 #include "numfont20x22.h"
 
+// Display width and height definition
+#define ILI9341_WIDTH     320
+#define ILI9341_HEIGHT    240
+
+// Display commands list
+#define ILI9341_NOP                        0x00
+#define ILI9341_SOFTWARE_RESET             0x01
+#define ILI9341_READ_IDENTIFICATION        0x04
+#define ILI9341_READ_STATUS                0x09
+#define ILI9341_READ_POWER_MODE            0x0A
+#define ILI9341_READ_MADCTL                0x0B
+#define ILI9341_READ_PIXEL_FORMAT          0x0C
+#define ILI9341_READ_IMAGE_FORMAT          0x0D
+#define ILI9341_READ_SIGNAL_MODE           0x0E
+#define ILI9341_READ_SELF_DIAGNOSTIC       0x0F
+#define ILI9341_SLEEP_IN                   0x10
+#define ILI9341_SLEEP_OUT                  0x11
+#define ILI9341_PARTIAL_MODE_ON            0x12
+#define ILI9341_NORMAL_DISPLAY_MODE_ON     0x13
+#define ILI9341_INVERSION_OFF              0x20
+#define ILI9341_INVERSION_ON               0x21
+#define ILI9341_GAMMA_SET                  0x26
+#define ILI9341_DISPLAY_OFF                0x28
+#define ILI9341_DISPLAY_ON                 0x29
+#define ILI9341_COLUMN_ADDRESS_SET         0x2A
+#define ILI9341_PAGE_ADDRESS_SET           0x2B
+#define ILI9341_MEMORY_WRITE               0x2C
+#define ILI9341_COLOR_SET                  0x2D
+#define ILI9341_MEMORY_READ                0x2E
+#define ILI9341_PARTIAL_AREA               0x30
+#define ILI9341_VERTICAL_SCROLLING_DEF     0x33
+#define ILI9341_TEARING_LINE_OFF           0x34
+#define ILI9341_TEARING_LINE_ON            0x35
+#define ILI9341_MEMORY_ACCESS_CONTROL      0x36
+#define ILI9341_VERTICAL_SCROLLING         0x37
+#define ILI9341_IDLE_MODE_OFF              0x38
+#define ILI9341_IDLE_MODE_ON               0x39
+#define ILI9341_PIXEL_FORMAT_SET           0x3A
+#define ILI9341_WRITE_MEMORY_CONTINUE      0x3C
+#define ILI9341_READ_MEMORY_CONTINUE       0x3E
+#define ILI9341_SET_TEAR_SCANLINE          0x44
+#define ILI9341_GET_SCANLINE               0x45
+#define ILI9341_WRITE_BRIGHTNESS           0x51
+#define ILI9341_READ_BRIGHTNESS            0x52
+#define ILI9341_WRITE_CTRL_DISPLAY         0x53
+#define ILI9341_READ_CTRL_DISPLAY          0x54
+#define ILI9341_WRITE_CA_BRIGHTNESS        0x55
+#define ILI9341_READ_CA_BRIGHTNESS         0x56
+#define ILI9341_WRITE_CA_MIN_BRIGHTNESS    0x5E
+#define ILI9341_READ_CA_MIN_BRIGHTNESS     0x5F
+#define ILI9341_READ_ID1                   0xDA
+#define ILI9341_READ_ID2                   0xDB
+#define ILI9341_READ_ID3                   0xDC
+#define ILI9341_RGB_INTERFACE_CONTROL      0xB0
+#define ILI9341_FRAME_RATE_CONTROL_1       0xB1
+#define ILI9341_FRAME_RATE_CONTROL_2       0xB2
+#define ILI9341_FRAME_RATE_CONTROL_3       0xB3
+#define ILI9341_DISPLAY_INVERSION_CONTROL  0xB4
+#define ILI9341_BLANKING_PORCH_CONTROL     0xB5
+#define ILI9341_DISPLAY_FUNCTION_CONTROL   0xB6
+#define ILI9341_ENTRY_MODE_SET             0xB7
+#define ILI9341_BACKLIGHT_CONTROL_1        0xB8
+#define ILI9341_BACKLIGHT_CONTROL_2        0xB9
+#define ILI9341_BACKLIGHT_CONTROL_3        0xBA
+#define ILI9341_BACKLIGHT_CONTROL_4        0xBB
+#define ILI9341_BACKLIGHT_CONTROL_5        0xBC
+#define ILI9341_BACKLIGHT_CONTROL_7        0xBE
+#define ILI9341_BACKLIGHT_CONTROL_8        0xBF
+#define ILI9341_POWER_CONTROL_1            0xC0
+#define ILI9341_POWER_CONTROL_2            0xC1
+#define ILI9341_VCOM_CONTROL_1             0xC5
+#define ILI9341_VCOM_CONTROL_2             0xC7
+#define ILI9341_POWERA                     0xCB
+#define ILI9341_POWERB                     0xCF
+#define ILI9341_NV_MEMORY_WRITE            0xD0
+#define ILI9341_NV_PROTECTION_KEY          0xD1
+#define ILI9341_NV_STATUS_READ             0xD2
+#define ILI9341_READ_ID4                   0xD3
+#define ILI9341_POSITIVE_GAMMA_CORRECTION  0xE0
+#define ILI9341_NEGATIVE_GAMMA_CORRECTION  0xE1
+#define ILI9341_DIGITAL_GAMMA_CONTROL_1    0xE2
+#define ILI9341_DIGITAL_GAMMA_CONTROL_2    0xE3
+#define ILI9341_DTCA                       0xE8
+#define ILI9341_DTCB                       0xEA
+#define ILI9341_POWER_SEQ                  0xED
+#define ILI9341_3GAMMA_EN                  0xF2
+#define ILI9341_INTERFACE_CONTROL          0xF6
+#define ILI9341_PUMP_RATIO_CONTROL         0xF7
+
+//
+// ILI9341_MEMORY_ACCESS_CONTROL registers
+//
+#define ILI9341_MADCTL_MY  0x80
+#define ILI9341_MADCTL_MX  0x40
+#define ILI9341_MADCTL_MV  0x20
+#define ILI9341_MADCTL_ML  0x10
+#define ILI9341_MADCTL_BGR 0x08
+#define ILI9341_MADCTL_MH  0x04
+#define ILI9341_MADCTL_RGB 0x00
+
+#define DISPLAY_ROTATION_270   (ILI9341_MADCTL_MX | ILI9341_MADCTL_BGR)
+#define DISPLAY_ROTATION_90    (ILI9341_MADCTL_MY | ILI9341_MADCTL_BGR)
+#define DISPLAY_ROTATION_0     (ILI9341_MADCTL_MV | ILI9341_MADCTL_BGR)
+#define DISPLAY_ROTATION_180   (ILI9341_MADCTL_MX | ILI9341_MADCTL_MY  \
+                              | ILI9341_MADCTL_MV | ILI9341_MADCTL_BGR)
+
+
 #define RESET_ASSERT	;
 #define RESET_NEGATE	;
 #define CS_LOW			digitalWrite(ili9341_conf_cs, LOW)
@@ -74,63 +181,67 @@ static void send_command(uint8_t cmd, int len, const uint8_t *data)
 }
 
 static const uint8_t ili9341_init_seq[] = {
-		// cmd, len, data...,
-		// Power control B
-		0xCF, 3, 0x00, 0x83, 0x30,
-		// Power on sequence control
-		0xED, 4, 0x64, 0x03, 0x12, 0x81,
-		//0xED, 4, 0x55, 0x01, 0x23, 0x01,
-		// Driver timing control A
-		0xE8, 3, 0x85, 0x01, 0x79,
-		//0xE8, 3, 0x84, 0x11, 0x7a,
-		// Power control A
-		0xCB, 5, 0x39, 0x2C, 0x00, 0x34, 0x02,
-		// Pump ratio control
-		0xF7, 1, 0x20,
-		// Driver timing control B
-		0xEA, 2, 0x00, 0x00,
-		// POWER_CONTROL_1
-		0xC0, 1, 0x26,
-		// POWER_CONTROL_2
-		0xC1, 1, 0x11,
-		// VCOM_CONTROL_1
-		0xC5, 2, 0x35, 0x3E,
-		// VCOM_CONTROL_2
-		0xC7, 1, 0xBE,
-		// MEMORY_ACCESS_CONTROL
-		//0x36, 1, 0x48, // portlait
-		0x36, 1, 0b00101000, // landscape
-		// COLMOD_PIXEL_FORMAT_SET : 16 bit pixel
-		0x3A, 1, 0x55,
-		// Frame Rate
-		0xB1, 2, 0x00, 0x1B,
-		// Gamma Function Disable
-		0xF2, 1, 0x08,
-		// gamma set for curve 01/2/04/08
-		0x26, 1, 0x01,
-		// positive gamma correction
-		0xE0, 15, 0x1F,  0x1A,  0x18,  0x0A,  0x0F,  0x06,  0x45,  0x87,  0x32,  0x0A,  0x07,  0x02,  0x07, 0x05,  0x00,
-		// negativ gamma correction
-		0xE1, 15, 0x00,  0x25,  0x27,  0x05,  0x10,  0x09,  0x3A,  0x78,  0x4D,  0x05,  0x18,  0x0D,  0x38, 0x3A,  0x1F,
-
-		// Column Address Set
-		0x2A, 4, 0x00, 0x00, 0x01, 0x3f, // width 320
-		// Page Address Set
-		0x2B, 4, 0x00, 0x00, 0x00, 0xef, // height 240
-
-		// entry mode
-		0xB7, 1, 0x06,
-		// display function control
-		0xB6, 4, 0x0A, 0x82, 0x27, 0x00,
-
-		// control display
-		//0x53, 1, 0x0c,
-		// diaplay brightness
-		//0x51, 1, 0xff,
-
-		// sleep out
-		0x11, 0,
-		0 // sentinel
+  // cmd, len, data...,
+  // SW reset
+  ILI9341_SOFTWARE_RESET, 0,
+  // display off
+  ILI9341_DISPLAY_OFF, 0,
+  // Power control B
+  ILI9341_POWERB, 3, 0x00, 0x83, 0x30,
+  // Power on sequence control
+  ILI9341_POWER_SEQ, 4, 0x64, 0x03, 0x12, 0x81,
+  //ILI9341_POWER_SEQ, 4, 0x55, 0x01, 0x23, 0x01,
+  // Driver timing control A
+  ILI9341_DTCA, 3, 0x85, 0x01, 0x79,
+  //ILI9341_DTCA, 3, 0x84, 0x11, 0x7a,
+  // Power control A
+  ILI9341_POWERA, 5, 0x39, 0x2C, 0x00, 0x34, 0x02,
+  // Pump ratio control
+  ILI9341_PUMP_RATIO_CONTROL, 1, 0x20,
+  // Driver timing control B
+  ILI9341_DTCB, 2, 0x00, 0x00,
+  // POWER_CONTROL_1
+  ILI9341_POWER_CONTROL_1, 1, 0x26,
+  // POWER_CONTROL_2
+  ILI9341_POWER_CONTROL_2, 1, 0x11,
+  // VCOM_CONTROL_1
+  ILI9341_VCOM_CONTROL_1, 2, 0x35, 0x3E,
+  // VCOM_CONTROL_2
+  ILI9341_VCOM_CONTROL_2, 1, 0xBE,
+  // MEMORY_ACCESS_CONTROL
+  //ILI9341_MEMORY_ACCESS_CONTROL, 1, 0x48, // portlait
+  ILI9341_MEMORY_ACCESS_CONTROL, 1, DISPLAY_ROTATION_0, // landscape
+  // COLMOD_PIXEL_FORMAT_SET : 16 bit pixel
+  ILI9341_PIXEL_FORMAT_SET, 1, 0x55,
+  // Frame Rate
+  ILI9341_FRAME_RATE_CONTROL_1, 2, 0x00, 0x1B,
+  // Gamma Function Disable
+  ILI9341_3GAMMA_EN, 1, 0x08,
+  // gamma set for curve 01/2/04/08
+  ILI9341_GAMMA_SET, 1, 0x01,
+  // positive gamma correction
+//ILI9341_POSITIVE_GAMMA_CORRECTION, 15, 0x1F,  0x1A,  0x18,  0x0A,  0x0F,  0x06,  0x45,  0x87,  0x32,  0x0A,  0x07,  0x02,  0x07, 0x05,  0x00,
+  // negativ gamma correction
+//ILI9341_NEGATIVE_GAMMA_CORRECTION, 15, 0x00,  0x25,  0x27,  0x05,  0x10,  0x09,  0x3A,  0x78,  0x4D,  0x05,  0x18,  0x0D,  0x38, 0x3A,  0x1F,
+  // Column Address Set
+//ILI9341_COLUMN_ADDRESS_SET, 4, 0x00, 0x00, 0x01, 0x3f, // width 320
+  // Page Address Set
+//ILI9341_PAGE_ADDRESS_SET, 4, 0x00, 0x00, 0x00, 0xef,   // height 240
+  // entry mode
+  ILI9341_ENTRY_MODE_SET, 1, 0x06,
+  // display function control
+  ILI9341_DISPLAY_FUNCTION_CONTROL, 4, 0x0A, 0x82, 0x27, 0x00,
+  // Interface Control (set WEMODE=0)
+  ILI9341_INTERFACE_CONTROL, 3, 0x00, 0x00, 0x00,
+  // control display
+  //ILI9341_WRITE_CTRL_DISPLAY, 1, 0x0c,
+  // diaplay brightness
+  //ILI9341_WRITE_BRIGHTNESS, 1, 0xff,
+  // sleep out
+  ILI9341_SLEEP_OUT, 0,
+  // display on
+  ILI9341_DISPLAY_ON, 0,
+  0 // sentinel
 };
 
 void
@@ -143,22 +254,23 @@ ili9341_init(void)
 
   ili9341_spi_wait_bulk();
 
-  send_command(0x01, 0, NULL); // SW reset
-  delay(5);
-  send_command(0x28, 0, NULL); // display off
-
   const uint8_t *p;
   for (p = ili9341_init_seq; *p; ) {
 	send_command(p[0], p[1], &p[2]);
 	p += 2 + p[1];
 	delay(5);
   }
-
-  delay(100);
-  send_command(0x29, 0, NULL); // display on
 }
 
-void ili9341_pixel(int x, int y, int color)
+static inline uint32_t __REV16(uint32_t rev)
+{
+	uint32_t a = __builtin_bswap16(rev >> 16);
+	uint32_t b = __builtin_bswap16(rev & 0xFFFF);
+	return (a << 16) | (b);
+}
+
+#if 0
+void ili9341_pixel(int x, int y, uint16_t color)
 {
 	uint8_t xx[4] = { x >> 8, x, (x+1) >> 8, (x+1) };
 	uint8_t yy[4] = { y >> 8, y, (y+1) >> 8, (y+1) };
@@ -169,18 +281,17 @@ void ili9341_pixel(int x, int y, int color)
 	send_command(0x2C, 2, cc);
 	//send_command16(0x2C, color);
 }
+#endif
 
-
-
-void ili9341_fill(int x, int y, int w, int h, int color)
+void ili9341_fill(int x, int y, int w, int h, uint16_t color)
 {
-	uint8_t xx[4] = { x >> 8, x, (x+w-1) >> 8, (x+w-1) };
-	uint8_t yy[4] = { y >> 8, y, (y+h-1) >> 8, (y+h-1) };
-	int len = w * h;
+	uint32_t len = w * h;
+	uint32_t xx = __REV16(x | ((x + w - 1) << 16));
+	uint32_t yy = __REV16(y | ((y + h - 1) << 16));
 	ili9341_spi_wait_bulk();
-	send_command(0x2A, 4, xx);
-	send_command(0x2B, 4, yy);
-	send_command(0x2C, 0, NULL);
+	send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t*)&xx);
+	send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
+	send_command(ILI9341_MEMORY_WRITE, 0, NULL);
 
 	constexpr int chunkSize = 512;
 	static_assert(chunkSize <= ili9341_bufferSize);
@@ -198,20 +309,16 @@ void ili9341_fill(int x, int y, int w, int h, int color)
 
 void ili9341_bulk(int x, int y, int w, int h)
 {
-	uint8_t xx[4] = { x >> 8, x, (x+w-1) >> 8, (x+w-1) };
-	uint8_t yy[4] = { y >> 8, y, (y+h-1) >> 8, (y+h-1) };
-	int len = w * h;
-
+	uint32_t len = w * h;
+	uint32_t xx = __REV16(x | ((x + w - 1) << 16));
+	uint32_t yy = __REV16(y | ((y + h - 1) << 16));
 	ili9341_spi_wait_bulk();
-
-    delayMicroseconds(10);
-
-	send_command(0x2A, 4, xx);
-	send_command(0x2B, 4, yy);
-	send_command(0x2C, 0, NULL);
+	send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t*)&xx);
+	send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
+	send_command(ILI9341_MEMORY_WRITE, 0, NULL);
 
 	ili9341_spi_transfer_bulk(len);
-	
+
 	// switch buffers so that the user can continue to render while
 	// the bulk transfer is happening.
 	if(ili9341_spi_buffer == ili9341_spi_bufferA)
@@ -243,13 +350,12 @@ ili9341_read_memory_raw(uint8_t cmd, int len, uint16_t* out)
 void
 ili9341_read_memory(int x, int y, int w, int h, int len, uint16_t *out)
 {
-	uint8_t xx[4] = { x >> 8, x, (x+w-1) >> 8, (x+w-1) };
-	uint8_t yy[4] = { y >> 8, y, (y+h-1) >> 8, (y+h-1) };
+	uint32_t xx = __REV16(x | ((x + w - 1) << 16));
+	uint32_t yy = __REV16(y | ((y + h - 1) << 16));
 	ili9341_spi_wait_bulk();
+	send_command(ILI9341_COLUMN_ADDRESS_SET, 4, (uint8_t *)&xx);
+	send_command(ILI9341_PAGE_ADDRESS_SET, 4, (uint8_t*)&yy);
 	
-	send_command(0x2A, 4, xx);
-	send_command(0x2B, 4, yy);
-
 	ili9341_read_memory_raw(0x2E, len, out);
 }
 
@@ -263,11 +369,13 @@ ili9341_read_memory_continue(int len, uint16_t* out)
 void
 ili9341_set_flip(bool flipX, bool flipY) {
 	ili9341_spi_wait_bulk();
-	uint8_t memAcc = 0b00101000;
-	if(flipX) memAcc |= 0b01000000;
-	if(flipY) memAcc |= 0b10000000;
-	send_command(0x36, 1, &memAcc);
+	uint8_t memAcc = ILI9341_MADCTL_BGR | ILI9341_MADCTL_MV;
+	if(flipX) memAcc |= ILI9341_MADCTL_MX;
+	if(flipY) memAcc |= ILI9341_MADCTL_MY;
+	send_command(ILI9341_MEMORY_ACCESS_CONTROL, 1, &memAcc);
 }
+
+
 
 void
 ili9341_drawchar_5x7(uint8_t ch, int x, int y, uint16_t fg, uint16_t bg)

--- a/ili9341.cpp
+++ b/ili9341.cpp
@@ -33,8 +33,8 @@
 
 uint16_t ili9341_spi_buffers[ili9341_bufferSize * 2];
 
-uint16_t* ili9341_spi_bufferA = ili9341_spi_buffers;
-uint16_t* ili9341_spi_bufferB = &ili9341_spi_buffers[ili9341_bufferSize];
+static uint16_t* const ili9341_spi_bufferA = ili9341_spi_buffers;
+static uint16_t* const ili9341_spi_bufferB = &ili9341_spi_buffers[ili9341_bufferSize];
 
 uint16_t* ili9341_spi_buffer = ili9341_spi_bufferA;
 
@@ -43,11 +43,6 @@ Pad ili9341_conf_dc;
 small_function<uint32_t(uint32_t sdi, int bits)> ili9341_spi_transfer;
 small_function<void(uint32_t words)> ili9341_spi_transfer_bulk;
 small_function<void()> ili9341_spi_wait_bulk;
-
-void ssp_wait(void)
-{
-}
-
 
 static inline void ssp_senddata(uint8_t x)
 {
@@ -64,11 +59,7 @@ static inline void ssp_senddata16(uint16_t x)
   ili9341_spi_transfer(x, 16);
 }
 
-uint32_t txdmamode;
-
-
-void
-send_command(uint8_t cmd, int len, const uint8_t *data)
+static void send_command(uint8_t cmd, int len, const uint8_t *data)
 {
 	CS_LOW;
 	DC_CMD;
@@ -82,20 +73,7 @@ send_command(uint8_t cmd, int len, const uint8_t *data)
 	//CS_HIGH;
 }
 
-void
-send_command16(uint8_t cmd, int data)
-{
-	CS_LOW;
-	DC_CMD;
-    delayMicroseconds(1);
-	ssp_senddata(cmd);
-	DC_DATA;
-    delayMicroseconds(1);
-	ssp_senddata16(byteReverse16(data));
-	CS_HIGH;
-}
-
-const uint8_t ili9341_init_seq[] = {
+static const uint8_t ili9341_init_seq[] = {
 		// cmd, len, data...,
 		// Power control B
 		0xCF, 3, 0x00, 0x83, 0x30,
@@ -435,7 +413,7 @@ ili9341_drawfont(uint8_t ch, const font_t *font, int x, int y, uint16_t fg, uint
 	ili9341_bulk(x, y, font->width, font->height);
 }
 
-#if 1
+#if 0
 const uint16_t colormap[] = {
   RGB565(255,0,0), RGB565(0,255,0), RGB565(0,0,255),
   RGB565(255,255,0), RGB565(0,255,255), RGB565(255,0,255)

--- a/ili9341.hpp
+++ b/ili9341.hpp
@@ -48,7 +48,7 @@ void ili9341_test(int mode);
 void ili9341_bulk(int x, int y, int w, int h);
 void ili9341_set_flip(bool flipX, bool flipY);
 void ili9341_line(int, int, int, int, int);
-void ili9341_fill(int x, int y, int w, int h, int color);
+void ili9341_fill(int x, int y, int w, int h, uint16_t color);
 void ili9341_drawchar_5x7(uint8_t ch, int x, int y, uint16_t fg, uint16_t bg);
 void ili9341_drawstring_5x7_inv(const char *str, int x, int y, uint16_t fg, uint16_t bg, bool inv);
 void ili9341_drawstring_5x7(const char *str, int x, int y, uint16_t fg, uint16_t bg);


### PR DESCRIPTION
I fixed all compile warnings in the display driver code, dropped unused code and use defines.
I used the defines and init sequence from @DisLord nanovna branch.