### PR TITLE
Set XTAL to fixed 24Mhz.

### DIFF
--- a/board_v2_1/board.cpp
+++ b/board_v2_1/board.cpp
@@ -257,7 +257,6 @@ namespace board {
 	// returns an estimate of the HSE frequency in Hz.
 	// called by boardInit() to set hseEstimateHz.
 	uint32_t detectHSEFreq() {
-		cpu_mhz = 8;
 		rcc_osc_on(RCC_HSE);
 		rcc_osc_on(RCC_HSI);
 		rtc_auto_awake(RCC_HSE, 1 << 19);

--- a/board_v2_1/board.hpp
+++ b/board_v2_1/board.hpp
@@ -61,8 +61,8 @@ namespace board {
 	// estimated HSE frequency in Hz, set by boardInit()
 	extern uint32_t hseEstimateHz;
 
-	// detected HSE frequency in Hz, rounded to a supported value, set by boardInit()
-	extern uint32_t xtalFreqHz;
+	// All boards use a 24Mhz TCXO. It gives best phase noise with the ADF4350
+	static constexpr uint32_t xtalFreqHz = 24000000; 
 
 	// ADC parameters, set by boardInit()
 	extern uint32_t adc_ratecfg;

--- a/main2.cpp
+++ b/main2.cpp
@@ -66,7 +66,7 @@ using namespace board;
 void* __dso_handle = (void*) &__dso_handle;
 
 static bool outputRawSamples = false;
-int cpu_mhz = 24;
+int cpu_mhz = 8; /* The CPU boots on internal (HSI) 8Mhz */
 
 
 static int lo_freq = 12000; // IF frequency, Hz

--- a/synthesizers.hpp
+++ b/synthesizers.hpp
@@ -38,10 +38,6 @@ namespace synthesizers {
 		uint64_t N = freqHz*O/freqStepHz;
 		uint32_t modulus = board::xtalFreqHz/R/freqStepHz;
 
-		if(board::xtalFreqHz > 32000000) {
-			modulus /= 2;
-			adf4350.refDiv2 = true;
-		}
 		adf4350.R = R;
 		adf4350.O = O;
 		adf4350.N = N / modulus;


### PR DESCRIPTION
Experiments have shown 24Mhz is best for the ADF4350 phase noise.
It allows to drop a check in ADF4350 to enabled an extra divider, which
un turn allows making that option a constat.
I did leave the detection for now. Perhaps we can add a warning when
XTAL is not 24Mhz.
I also left the 120Mhz option for when someone want to have a try with
that.