### PR TITLE
Adf4350 powerdown fix

### DIFF
--- a/main2.cpp
+++ b/main2.cpp
@@ -847,16 +847,6 @@ static void setVNASweepToUI() {
 	vnaMeasurement.setSweep(start, step, current_props._sweep_points, 1);
 	ecalState = ECAL_STATE_MEASURING;
 	update_grid();
-	if(!is_freq_for_adf4350(stop)) {
-		/* ADF4350 can be powered down */
-		adf4350_powerdown();
-	}
-	else {
-		adf4350_powerup();
-	}
-	if(is_freq_for_adf4350(start)) {
-		/* Si5351 not needed, power it down? */
-	}
 }
 
 static void measurement_setup() {
@@ -868,6 +858,18 @@ static void measurement_setup() {
 	};
 	vnaMeasurement.frequencyChanged = [](freqHz_t freqHz) {
 		setFrequency(freqHz);
+	};
+	vnaMeasurement.sweepSetupChanged = [](freqHz_t start, freqHz_t stop) {
+		if(!is_freq_for_adf4350(stop)) {
+			/* ADF4350 can be powered down */
+			adf4350_powerdown();
+		}
+		else {
+			adf4350_powerup();
+		}
+		if(is_freq_for_adf4350(start)) {
+			/* Si5351 not needed, power it down? */
+		}
 	};
 	vnaMeasurement.nPeriods = MEASUREMENT_NPERIODS_NORMAL;
 	vnaMeasurement.init();

--- a/vna_measurement.cpp
+++ b/vna_measurement.cpp
@@ -1,7 +1,7 @@
 #include "vna_measurement.hpp"
 
 VNAMeasurement::VNAMeasurement(): sampleProcessor(_emitValue_t {this}) {
-	
+
 }
 
 void VNAMeasurement::init() {
@@ -59,6 +59,9 @@ void VNAMeasurement::sweepAdvance() {
 void VNAMeasurement::sampleProcessor_emitValue(int32_t valRe, int32_t valIm) {
 	auto currPoint = sweepCurrPoint;
 	if(currPoint == -1) {
+		freqHz_t start = sweepStartHz;
+		freqHz_t stop = start + sweepStepHz*sweepPoints;
+		sweepSetupChanged(start, stop);
 		dpCounterSynth = 0;
 		setMeasurementPhase(VNAMeasurementPhases::REFERENCE);
 		sweepAdvance();

--- a/vna_measurement.hpp
+++ b/vna_measurement.hpp
@@ -55,6 +55,9 @@ public:
 	// called to change synthesizer frequency
 	small_function<void(freqHz_t freqHz)> frequencyChanged;
 
+	// called when sweep setup change is process in measurement 'thread'
+	small_function<void(freqHz_t start, freqHz_t stop)> sweepSetupChanged;
+
 	VNAMeasurement();
 
 	void init();
@@ -70,7 +73,7 @@ public:
 		VNAMeasurement* m;
 		void operator()(int32_t* valRe, int32_t* valIm);
 	};
-	
+
 	SampleProcessor<_emitValue_t> sampleProcessor;
 
 public:
@@ -102,7 +105,7 @@ public:
 	int sweepDataPointsPerFreq = 1;
 
 	uint64_t currFreq;
-	
+
 	complexf ecal[ECAL_CHANNELS];
 
 


### PR DESCRIPTION
I had this fixed on the original pull request but only a few hours AFTER the branch was merged. Sorry about that.
The problem we are fixing here is that we are powering down the ADF4350 from the "main" thread, while the "ADC" thread actually "owns" the ADF4350; aka there is change the ADC thread interrupts the powerdown sequence. and thus leaving the ADF4350 in a unknown state.
It probably does not cause any trouble since the sweep is not using the ADF4350 anymore. When ADF4350 is used again the device is properly configured again.