### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,45 @@ See https://www.nanorfe.com for more info.
 Below is information for building the firmware on Linux.
 
 ## Installing the compiler
+
+### Debian based systems
+
 On any recent Debian based installation:
 ``` 
-apt install arm-gcc-none-eabi python3-serial
+sudo apt install gcc-arm-none-eabi
+```
+
+### Installing the upstream toolchain
+
+If you want to install the latest version of the gnu ARM toolchain:
+
+1. get the latest version from https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads . You can download it using your browser or a command line tool like `wget`:
+```
+wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2
+```
+
+2. untar it, eg. in `/opt/toolchains`:
+```
+sudo mkdir -p /opt/toolchains
+sudo tar xvf -C /opt/toolchains gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2
+```
+
+3. set your PATH environment variable:
+```
+export PATH=/opt/toolchains/gcc-arm-none-eabi-9-2020-q2-update/bin:$PATH
+```
+
+## Installing dependencies
+
+To upload the firmware on the NanoVNA2, you will need:
+
+- Python 3
+- [pyserial](https://github.com/pyserial/pyserial)
+
+On a Debian based system, you can use:
+
+```
+sudo apt install python3-serial
 ```
 
 ## Getting all source code
@@ -26,24 +62,16 @@ make
 cd ..
 ```
 
-Now edit the Makefile to point to the correct library
+Set these 2 environment variables so they point to the directories that where created during the git checkout:
 ```
-cd NanoVNA-V2-firmware
-```
-open the Makefile in your favorite editor and change the two lines with
-```
-MCULIB         ?= /persist/mculib
-OPENCM3_DIR    ?= /persist/libopencm3
-```
-So they point to the directories that where create during the checkout:
-```
-MCULIB         ?= /home/YOUR-USER/mculib
-OPENCM3_DIR    ?= /home/YOUR-USER/libopencm3-gd32f3
+export MCULIB=$PWD/mculib
+export OPENCM3_DIR=$PWD/libopencm3-gd32f3
 ```
 
 ## Building
-Now you can build the firmware by running make:
+Now you can build the firmware by running make in the firmware sources directory:
 ```
+cd NanoVNA-V2-firmware
 make
 ```
 
@@ -61,7 +89,6 @@ Switch the device off
 Press and hold down the left button (the one closest to the Port 1 or the On/Off switch)
 Switch the device on (screen stays white), release the button
 ```
-
 
 The current user probably needs to be part of the dialout group to allow access.
 


### PR DESCRIPTION
Improve the compiler setup description for Debian (for which the `arm-gcc-none-eabi` package does exists), and document the use of environment variables instead of modifying the `Makefile`.