### PR TITLE
Fix typo install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Below is information for building the firmware on Linux.
 ## Installing the compiler
 On any recent Debian based installation:
 ``` 
-apt install arm-gcc-none-eabi python3-serial
+apt install gcc-arm-none-eabi python3-serial
 ```
 
 ## Getting all source code


### PR DESCRIPTION
I swapped arm and gcc in the debian package name.