### PR TITLE
bootloader: add a atoll() definition in main.c

### DIFF
--- a/bootloader/main.cpp
+++ b/bootloader/main.cpp
@@ -484,6 +484,10 @@ extern "C" int atoi(const char* s) {
 	// TODO: implement
 	return 0;
 }
+extern "C" long atoll(const char* s) {
+	// TODO: implement
+	return 0;
+}
 extern "C" void __aeabi_atexit(void * arg , void (* func ) (void *)) {
 	// Leave this function empty. Program never exits.
 }


### PR DESCRIPTION
this is needed to prevent a linker error (undefined reference) since common.c,
which is embedded in the bootloader image, now uses this atoll function
(since e4fecad7).

Fixes issue #26.