### PR TITLE
Use more compact FFT table

### DIFF
--- a/common.hpp
+++ b/common.hpp
@@ -52,7 +52,7 @@ static constexpr uint32_t FREQUENCY_CHANGE_OVER	= 140000000;
 #define USB_POINTS_MAX 1024
 #define TRACES_MAX 4
 #define MARKERS_MAX 4
-#define FFT_SIZE 512
+#define FFT_SIZE 256
 #define ECAL_PARTIAL
 
 #ifdef ECAL_PARTIAL

--- a/fft.hpp
+++ b/fft.hpp
@@ -32,12 +32,12 @@
  * dir = forward: 0, inverse: 1
  * https://www.nayuki.io/res/free-small-fft-in-multiple-languages/fft.c
  */
-void fft512(float array[][2], const uint8_t dir);
+void fft(float array[][2], const uint8_t dir);
 
-static inline void fft512_forward(float array[][2]) {
-	fft512(array, 0);
+static inline void fft_forward(float array[][2]) {
+	fft(array, 0);
 }
 
-static inline void fft512_inverse(float array[][2]) {
-	fft512(array, 1);
+static inline void fft_inverse(float array[][2]) {
+	fft(array, 1);
 }

--- a/main2.cpp
+++ b/main2.cpp
@@ -1015,7 +1015,7 @@ static void transform_domain() {
 			}
 		}
 
-		fft512_inverse((float(*)[2])tmp);
+		fft_inverse((float(*)[2])tmp);
 		memcpy(measured[ch], tmp, sizeof(measured[0]));
 		for (int i = 0; i < points; i++) {
 			measured[ch][i] /= (float)FFT_SIZE;


### PR DESCRIPTION
Made FFT optimization

Add 2 variants 256 and 512 FFT (defined by FFT_SIZE from common.hpp)
Not need use 512 FFT for 201 points, possibly use 256 FFT
no any depend from lowpass for data size (offset and window_size), only
float w = kaiser_window(i + offset, window_size, beta);