### PR TITLE
Fix graticule display in zero span mode

### DIFF
--- a/plot.cpp
+++ b/plot.cpp
@@ -86,8 +86,15 @@ float2int(float v)
 	return 0;
 }
 
-void update_grid(void)
+void recalculate_grid(void)
 {
+	// no horizontal grid in zero-span mode
+	if (frequency1 == 0) {
+		grid_offset = 0;
+		grid_width = 10 * WIDTH;
+		return;
+	}
+
 	freqHz_t gdigit = 100000000;
 	freqHz_t fstart, fspan;
 	freqHz_t grid;
@@ -115,7 +122,11 @@ void update_grid(void)
 
 	grid_offset = WIDTH * ((fstart % fgrid) / 100) / (fspan / 100);
 	grid_width = WIDTH * (fgrid / 100) / (fspan / 1000);
+}
 
+void update_grid(void)
+{
+	recalculate_grid();
 	force_set_markmap();
 	redraw_request |= REDRAW_FREQUENCY;
 }

--- a/plot.hpp
+++ b/plot.hpp
@@ -71,6 +71,7 @@ void plot_init(void);
 
 // cancel ongoing draw operations further up the stack
 void plot_cancel();
+void recalculate_grid(void);
 void update_grid(void);
 void request_to_redraw_grid(void);
 void redraw_frame(void);


### PR DESCRIPTION
The calculation of the horizontal grid does not work when the span is zero. This leads to vertical lines drawn at every point, so the background becomes flat gray and the Smith chart is no longer visible (as reported here: https://groups.io/g/NanoVNA-V2/message/1146).
This pull request sets the grid width to the whole frame in zero span mode, so there is no horizontal grid. This also serves as a visual cue that a time sweep is displayed instead of a frequency sweep.