### PR TITLE
Rework capture code and fix marker hang issue

### DIFF
--- a/board_v2_0/board.cpp
+++ b/board_v2_0/board.cpp
@@ -221,16 +221,26 @@ namespace board {
 		
 		spi_enable_tx_dma(SPI1);
 
+		// Set to tx+rx mode
+		spi_set_unidirectional_mode(SPI1);
+
 		/* Enable SPI1 periph. */
 		spi_enable(SPI1);
 	}
-	void lcd_spi_fast() {
-		spi_set_baudrate_prescaler(SPI1, 0b001);
+	void lcd_spi_write() {
+		spi_set_baudrate_prescaler(SPI1,SPI_CR1_BR_FPCLK_DIV_4);
+	}
+	void lcd_spi_read() {
+		spi_set_baudrate_prescaler(SPI1, SPI_CR1_BR_FPCLK_DIV_8);
 	}
 	void lcd_spi_slow() {
-		spi_set_baudrate_prescaler(SPI1, 0b110);
+		spi_set_baudrate_prescaler(SPI1, SPI_CR1_BR_FPCLK_DIV_16);
 	}
-	
+	void spi_drop_read() {
+		uint16_t data;
+		data = SPI_DR(SPI1); // Cleanup read buffers in SPI hardware
+		data = SPI_DR(SPI1);
+	}
 	bool lcd_spi_isDMAInProgress = false;
 	
 	void lcd_spi_waitDMA() {
@@ -245,8 +255,6 @@ namespace board {
 		while (!(SPI_SR(SPI1) & SPI_SR_TXE));
 		while ((SPI_SR(SPI1) & SPI_SR_BSY));
 		
-		// switch back to tx+rx mode
-		spi_set_unidirectional_mode(SPI1);
 		lcd_spi_isDMAInProgress = false;
 //		delayMicroseconds(10);
 	}
@@ -254,11 +262,11 @@ namespace board {
 	uint32_t lcd_spi_transfer(uint32_t sdi, int bits) {
 		if(lcd_spi_isDMAInProgress)
 			lcd_spi_waitDMA();
-		uint32_t ret = 0;
+		spi_drop_read();
+		uint32_t ret = spi_xfer(SPI1, (uint16_t) sdi);
 		if(bits == 16) {
-			ret = uint32_t(spi_xfer(SPI1, (uint16_t) (sdi >> 8))) << 8;
+			ret|= uint32_t(spi_xfer(SPI1, (uint16_t) (sdi >> 8))) << 8;
 		}
-		ret |= spi_xfer(SPI1, (uint16_t) sdi);
 		return ret;
 	}
 
@@ -267,9 +275,6 @@ namespace board {
 			lcd_spi_waitDMA();
 
 		lcd_spi_isDMAInProgress = true;
-
-		// switch to tx only mode (do not put garbage in rx register)
-		spi_set_bidirectional_transmit_only_mode(SPI1);
 		DMATransferParams srcParams, dstParams;
 		srcParams.address = buf;
 		srcParams.bytesPerWord = 1;
@@ -284,5 +289,37 @@ namespace board {
 								bytes, false);
 		dmaChannelSPI.start();
 		//lcd_spi_waitDMA();
+	}
+
+	void lcd_spi_read_bulk(uint8_t* buf, int bytes) {
+		if(lcd_spi_isDMAInProgress)
+			lcd_spi_waitDMA();
+		// Switch to read speed
+		lcd_spi_read();
+		// Drop old data in rx buffers
+		spi_drop_read();
+#if 0
+		lcd_spi_isDMAInProgress = true;
+		DMATransferParams srcParams, dstParams;
+		srcParams.address = &SPI_DR(SPI1);
+		srcParams.bytesPerWord = 1;
+		srcParams.increment = false;
+
+		dstParams.address = buf;
+		dstParams.bytesPerWord = 1;
+		dstParams.increment = true;
+
+		dmaChannelSPI.setTransferParams(srcParams, dstParams,
+								DMADirection::PERIPHERAL_TO_MEMORY,
+								bytes, false);
+		dmaChannelSPI.start();
+		lcd_spi_waitDMA();
+#else
+		do{
+			*buf++= spi_xfer(SPI1, (uint16_t)0);
+		}while(--bytes);
+#endif
+		// Switch back to normal
+		lcd_spi_write();
 	}
 }

--- a/board_v2_0/board.cpp
+++ b/board_v2_0/board.cpp
@@ -237,9 +237,8 @@ namespace board {
 		spi_set_baudrate_prescaler(SPI1, SPI_CR1_BR_FPCLK_DIV_16);
 	}
 	void spi_drop_read() {
-		uint16_t data;
-		data = SPI_DR(SPI1); // Cleanup read buffers in SPI hardware
-		data = SPI_DR(SPI1);
+		(void)SPI_DR(SPI1); // Cleanup read buffers in SPI hardware
+		(void)SPI_DR(SPI1);
 	}
 	bool lcd_spi_isDMAInProgress = false;
 	

--- a/board_v2_0/board.hpp
+++ b/board_v2_0/board.hpp
@@ -164,15 +164,18 @@ namespace board {
 	// spi peripheral only manages clk, sdi, and sdo.
 	void lcd_spi_init();
 
-	// two speed presets for ili9341 and touch controller
-	void lcd_spi_fast();
+	// three speed presets for ili9341 write/read and touch controller
+	void lcd_spi_write();
+	void lcd_spi_read();
 	void lcd_spi_slow();
 
 	// bits must be 16 or 8
 	uint32_t lcd_spi_transfer(uint32_t sdi, int bits);
 
 	void lcd_spi_transfer_bulk(uint8_t* buf, int bytes);
-	
+
+	void lcd_spi_read_bulk(uint8_t* buf, int bytes);
+
 	// wait for all bulk transfers to complete
 	void lcd_spi_waitDMA();
 }

--- a/board_v2_1/board.cpp
+++ b/board_v2_1/board.cpp
@@ -325,16 +325,25 @@ namespace board {
 		
 		spi_enable_tx_dma(SPI1);
 
+		// Set to tx+rx mode
+		spi_set_unidirectional_mode(SPI1);
+
 		/* Enable SPI1 periph. */
 		spi_enable(SPI1);
 	}
-	void lcd_spi_fast() {
-		spi_set_baudrate_prescaler(SPI1, 0b001);
+	void lcd_spi_write() {
+		spi_set_baudrate_prescaler(SPI1,SPI_CR1_BR_FPCLK_DIV_4);
+	}
+	void lcd_spi_read() {
+		spi_set_baudrate_prescaler(SPI1, SPI_CR1_BR_FPCLK_DIV_8);
 	}
 	void lcd_spi_slow() {
-		spi_set_baudrate_prescaler(SPI1, 0b110);
+		spi_set_baudrate_prescaler(SPI1, SPI_CR1_BR_FPCLK_DIV_16);
 	}
-	
+	void spi_drop_read() {
+		(void)SPI_DR(SPI1); // Cleanup read buffers in SPI hardware
+		(void)SPI_DR(SPI1);
+	}
 	bool lcd_spi_isDMAInProgress = false;
 	
 	void lcd_spi_waitDMA() {
@@ -349,8 +358,6 @@ namespace board {
 		while (!(SPI_SR(SPI1) & SPI_SR_TXE));
 		while ((SPI_SR(SPI1) & SPI_SR_BSY));
 		
-		// switch back to tx+rx mode
-		spi_set_unidirectional_mode(SPI1);
 		lcd_spi_isDMAInProgress = false;
 //		delayMicroseconds(10);
 	}
@@ -358,10 +365,10 @@ namespace board {
 	uint32_t lcd_spi_transfer(uint32_t sdi, int bits) {
 		if(lcd_spi_isDMAInProgress)
 			lcd_spi_waitDMA();
-		uint32_t ret = 0;
-		ret |= spi_xfer(SPI1, (uint16_t) sdi);
+		spi_drop_read();
+		uint32_t ret = spi_xfer(SPI1, (uint16_t) sdi);
 		if(bits == 16) {
-			ret = uint32_t(spi_xfer(SPI1, (uint16_t) (sdi >> 8))) << 8;
+			ret|= uint32_t(spi_xfer(SPI1, (uint16_t) (sdi >> 8))) << 8;
 		}
 		return ret;
 	}
@@ -371,9 +378,6 @@ namespace board {
 			lcd_spi_waitDMA();
 
 		lcd_spi_isDMAInProgress = true;
-
-		// switch to tx only mode (do not put garbage in rx register)
-		spi_set_bidirectional_transmit_only_mode(SPI1);
 		DMATransferParams srcParams, dstParams;
 		srcParams.address = buf;
 		srcParams.bytesPerWord = 1;
@@ -388,5 +392,37 @@ namespace board {
 								bytes, false);
 		dmaChannelSPI.start();
 		//lcd_spi_waitDMA();
+	}
+
+	void lcd_spi_read_bulk(uint8_t* buf, int bytes) {
+		if(lcd_spi_isDMAInProgress)
+			lcd_spi_waitDMA();
+		// Switch to read speed
+		lcd_spi_read();
+		// Drop old data in rx buffers
+		spi_drop_read();
+#if 0
+		lcd_spi_isDMAInProgress = true;
+		DMATransferParams srcParams, dstParams;
+		srcParams.address = &SPI_DR(SPI1);
+		srcParams.bytesPerWord = 1;
+		srcParams.increment = false;
+
+		dstParams.address = buf;
+		dstParams.bytesPerWord = 1;
+		dstParams.increment = true;
+
+		dmaChannelSPI.setTransferParams(srcParams, dstParams,
+								DMADirection::PERIPHERAL_TO_MEMORY,
+								bytes, false);
+		dmaChannelSPI.start();
+		lcd_spi_waitDMA();
+#else
+		do{
+			*buf++= spi_xfer(SPI1, (uint16_t)0);
+		}while(--bytes);
+#endif
+		// Switch back to normal
+		lcd_spi_write();
 	}
 }

--- a/board_v2_1/board.hpp
+++ b/board_v2_1/board.hpp
@@ -173,15 +173,18 @@ namespace board {
 	// spi peripheral only manages clk, sdi, and sdo.
 	void lcd_spi_init();
 
-	// two speed presets for ili9341 and touch controller
-	void lcd_spi_fast();
+	// three speed presets for ili9341 write/read and touch controller
+	void lcd_spi_write();
+	void lcd_spi_read();
 	void lcd_spi_slow();
 
 	// bits must be 16 or 8
 	uint32_t lcd_spi_transfer(uint32_t sdi, int bits);
 
 	void lcd_spi_transfer_bulk(uint8_t* buf, int bytes);
-	
+
+	void lcd_spi_read_bulk(uint8_t* buf, int bytes);
+
 	// wait for all bulk transfers to complete
 	void lcd_spi_waitDMA();
 }

--- a/board_v2_plus/board.cpp
+++ b/board_v2_plus/board.cpp
@@ -327,9 +327,8 @@ namespace board {
 		spi_set_baudrate_prescaler(SPI1, SPI_CR1_BR_FPCLK_DIV_16);
 	}
 	void spi_drop_read() {
-		uint16_t data;
-		data = SPI_DR(SPI1); // Cleanup read buffers in SPI hardware
-		data = SPI_DR(SPI1);
+		(void)SPI_DR(SPI1); // Cleanup read buffers in SPI hardware
+		(void)SPI_DR(SPI1);
 	}
 	bool lcd_spi_isDMAInProgress = false;
 	

--- a/board_v2_plus/board.hpp
+++ b/board_v2_plus/board.hpp
@@ -173,15 +173,18 @@ namespace board {
 	// spi peripheral only manages clk, sdi, and sdo.
 	void lcd_spi_init();
 
-	// two speed presets for ili9341 and touch controller
-	void lcd_spi_fast();
+	// three speed presets for ili9341 write/read and touch controller
+	void lcd_spi_write();
+	void lcd_spi_read();
 	void lcd_spi_slow();
 
 	// bits must be 16 or 8
 	uint32_t lcd_spi_transfer(uint32_t sdi, int bits);
 
 	void lcd_spi_transfer_bulk(uint8_t* buf, int bytes);
-	
+
+	void lcd_spi_read_bulk(uint8_t* buf, int bytes);
+
 	// wait for all bulk transfers to complete
 	void lcd_spi_waitDMA();
 }

--- a/board_v2_plus4/board.cpp
+++ b/board_v2_plus4/board.cpp
@@ -310,9 +310,8 @@ namespace board {
 		spi_set_baudrate_prescaler(SPI1, SPI_CR1_BR_FPCLK_DIV_16);
 	}
 	void spi_drop_read() {
-		uint16_t data;
-		data = SPI_DR(SPI1); // Cleanup read buffers in SPI hardware
-		data = SPI_DR(SPI1);
+		(void)SPI_DR(SPI1); // Cleanup read buffers in SPI hardware
+		(void)SPI_DR(SPI1);
 	}
 	bool lcd_spi_isDMAInProgress = false;
 	

--- a/board_v2_plus4/board.cpp
+++ b/board_v2_plus4/board.cpp
@@ -294,16 +294,26 @@ namespace board {
 		
 		spi_enable_tx_dma(SPI1);
 
+		// Set to tx+rx mode
+		spi_set_unidirectional_mode(SPI1);
+
 		/* Enable SPI1 periph. */
 		spi_enable(SPI1);
 	}
-	void lcd_spi_fast() {
-		spi_set_baudrate_prescaler(SPI1, 0b001);
+	void lcd_spi_write() {
+		spi_set_baudrate_prescaler(SPI1,SPI_CR1_BR_FPCLK_DIV_4);
+	}
+	void lcd_spi_read() {
+		spi_set_baudrate_prescaler(SPI1, SPI_CR1_BR_FPCLK_DIV_8);
 	}
 	void lcd_spi_slow() {
-		spi_set_baudrate_prescaler(SPI1, 0b110);
+		spi_set_baudrate_prescaler(SPI1, SPI_CR1_BR_FPCLK_DIV_16);
 	}
-	
+	void spi_drop_read() {
+		uint16_t data;
+		data = SPI_DR(SPI1); // Cleanup read buffers in SPI hardware
+		data = SPI_DR(SPI1);
+	}
 	bool lcd_spi_isDMAInProgress = false;
 	
 	void lcd_spi_waitDMA() {
@@ -318,8 +328,6 @@ namespace board {
 		while (!(SPI_SR(SPI1) & SPI_SR_TXE));
 		while ((SPI_SR(SPI1) & SPI_SR_BSY));
 		
-		// switch back to tx+rx mode
-		spi_set_unidirectional_mode(SPI1);
 		lcd_spi_isDMAInProgress = false;
 //		delayMicroseconds(10);
 	}
@@ -327,10 +335,10 @@ namespace board {
 	uint32_t lcd_spi_transfer(uint32_t sdi, int bits) {
 		if(lcd_spi_isDMAInProgress)
 			lcd_spi_waitDMA();
-		uint32_t ret = 0;
-		ret |= spi_xfer(SPI1, (uint16_t) sdi);
+		spi_drop_read();
+		uint32_t ret = spi_xfer(SPI1, (uint16_t) sdi);
 		if(bits == 16) {
-			ret = uint32_t(spi_xfer(SPI1, (uint16_t) (sdi >> 8))) << 8;
+			ret|= uint32_t(spi_xfer(SPI1, (uint16_t) (sdi >> 8))) << 8;
 		}
 		return ret;
 	}
@@ -340,9 +348,6 @@ namespace board {
 			lcd_spi_waitDMA();
 
 		lcd_spi_isDMAInProgress = true;
-
-		// switch to tx only mode (do not put garbage in rx register)
-		spi_set_bidirectional_transmit_only_mode(SPI1);
 		DMATransferParams srcParams, dstParams;
 		srcParams.address = buf;
 		srcParams.bytesPerWord = 1;
@@ -357,5 +362,37 @@ namespace board {
 								bytes, false);
 		dmaChannelSPI.start();
 		//lcd_spi_waitDMA();
+	}
+
+	void lcd_spi_read_bulk(uint8_t* buf, int bytes) {
+		if(lcd_spi_isDMAInProgress)
+			lcd_spi_waitDMA();
+		// Switch to read speed
+		lcd_spi_read();
+		// Drop old data in rx buffers
+		spi_drop_read();
+#if 0
+		lcd_spi_isDMAInProgress = true;
+		DMATransferParams srcParams, dstParams;
+		srcParams.address = &SPI_DR(SPI1);
+		srcParams.bytesPerWord = 1;
+		srcParams.increment = false;
+
+		dstParams.address = buf;
+		dstParams.bytesPerWord = 1;
+		dstParams.increment = true;
+
+		dmaChannelSPI.setTransferParams(srcParams, dstParams,
+								DMADirection::PERIPHERAL_TO_MEMORY,
+								bytes, false);
+		dmaChannelSPI.start();
+		lcd_spi_waitDMA();
+#else
+		do{
+			*buf++= spi_xfer(SPI1, (uint16_t)0);
+		}while(--bytes);
+#endif
+		// Switch back to normal
+		lcd_spi_write();
 	}
 }

--- a/board_v2_plus4/board.hpp
+++ b/board_v2_plus4/board.hpp
@@ -164,20 +164,22 @@ namespace board {
 	void ledPulse();
 
 	int calculateSynthWait(bool, int);
-
 	// sets up hardware spi for ili9341 and touch.
 	// spi peripheral only manages clk, sdi, and sdo.
 	void lcd_spi_init();
 
-	// two speed presets for ili9341 and touch controller
-	void lcd_spi_fast();
+	// three speed presets for ili9341 write/read and touch controller
+	void lcd_spi_write();
+	void lcd_spi_read();
 	void lcd_spi_slow();
 
 	// bits must be 16 or 8
 	uint32_t lcd_spi_transfer(uint32_t sdi, int bits);
 
 	void lcd_spi_transfer_bulk(uint8_t* buf, int bytes);
-	
+
+	void lcd_spi_read_bulk(uint8_t* buf, int bytes);
+
 	// wait for all bulk transfers to complete
 	void lcd_spi_waitDMA();
 }

--- a/ili9341.hpp
+++ b/ili9341.hpp
@@ -56,6 +56,9 @@ extern small_function<uint32_t(uint32_t sdi, int bits)> ili9341_spi_transfer;
 // write spi_buffer to spi bus up to bytes without waiting for completion
 extern small_function<void(uint32_t words)> ili9341_spi_transfer_bulk;
 
+// read to buffer from spi bus up to bytes, waiting for completion aftrer
+extern small_function<void(uint8_t *buf, uint32_t bytes)> ili9341_spi_read;
+
 // wait for bulk transfers to complete
 extern small_function<void()> ili9341_spi_wait_bulk;
 
@@ -80,5 +83,4 @@ void ili9341_drawstring(const char *str, int len, int x, int y);
 //int ili9341_drawchar_size(uint8_t ch, int x, int y, uint8_t size);
 void ili9341_drawstring_size(const char *str, int x, int y, uint8_t size);
 void ili9341_drawfont(uint8_t ch, int x, int y);
-void ili9341_read_memory(int x, int y, int w, int h, int len, uint16_t* out);
-void ili9341_read_memory_continue(int len, uint16_t* out);
+void ili9341_read_memory(int x, int y, int w, int h, uint16_t* out);

--- a/python/nanovna.py
+++ b/python/nanovna.py
@@ -217,7 +217,7 @@ class NanoVNA:
         x = struct.unpack(">76800H", b)
         # convert pixel format from 565(RGB) to 8888(RGBA)
         arr = np.array(x, dtype=np.uint32)
-        arr = 0xFF000000 + ((arr & 0xF800) >> 8) + ((arr & 0x07E0) << 5) + ((arr & 0x001F) << 19)
+        arr = 0xFF000000 + ((arr & 0xF800) << 8) + ((arr & 0x07E0) << 5) + ((arr & 0x001F) << 3)
         return Image.frombuffer('RGBA', (320, 240), arr, 'raw', 'RGBA', 0, 1)
 
     def logmag(self, x):

--- a/python/nanovna.py
+++ b/python/nanovna.py
@@ -217,7 +217,7 @@ class NanoVNA:
         x = struct.unpack(">76800H", b)
         # convert pixel format from 565(RGB) to 8888(RGBA)
         arr = np.array(x, dtype=np.uint32)
-        arr = 0xFF000000 + ((arr & 0xF800) << 8) + ((arr & 0x07E0) << 5) + ((arr & 0x001F) << 3)
+        arr = 0xFF000000 + ((arr & 0xF800) >> 8) + ((arr & 0x07E0) << 5) + ((arr & 0x001F) << 19)
         return Image.frombuffer('RGBA', (320, 240), arr, 'raw', 'RGBA', 0, 1)
 
     def logmag(self, x):

--- a/xpt2046.cpp
+++ b/xpt2046.cpp
@@ -91,7 +91,7 @@ void XPT2046::getRaw (uint16_t &vi, uint16_t &vj, adc_ref_t mode, uint8_t max_sa
 		spiTransfer(CTRL_HI_Y | CTRL_LO_SER, 8);
 	}
 	spiTransfer(0, 16);  // Flush last read, just to be sure
-	
+	spiTransfer(0, 16);
 	spiSetCS(false);
 }
 


### PR DESCRIPTION
- remove double read from LCD
- implement read from 4 inch displays
- made read from display on less speed (prevent data corrupt for 4 inch)
- made capture header byte align
Fix drag marker issue, now it more stable:
- more fast touch data read
- fix 16 bit SPI bus transfer
- remove delays
- remove bidirectional/unidirectional SPI bus switch (now always use bi)
Now if ask 0 points device return all data in one req